### PR TITLE
Add endless directory scanning loop

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.idea
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY scanner.py ./
+ENTRYPOINT ["python", "scanner.py"]
+CMD ["."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY scanner.py ./
 ENTRYPOINT ["python", "scanner.py"]
-CMD ["."]
+CMD ["/scanmedia"]

--- a/README.md
+++ b/README.md
@@ -30,5 +30,18 @@ remains in the scanned folder. If one of two identical files contains media
 metadata while the other does not, the metadata-rich file is kept and the other
 is moved.
 
+You can exclude certain file extensions from scanning by setting the
+`fileextexept` environment variable. Provide a comma-separated list of
+extensions (with leading dots). The scanner prints the excluded extensions at
+the start of each run:
+
+```bash
+docker run --rm -v /path/to/scan:/scanmedia \
+  -e fileextexept=".old,.filesync" uniquemedia-scanner
+```
+
+In this example, files ending with `.old` or `.filesync` will be ignored during
+the scan.
+
 If you need to process media files with `ffmpeg`, the binary is available in the
 container at `/ffmpeg`.

--- a/README.md
+++ b/README.md
@@ -44,5 +44,7 @@ docker run --rm -v /path/to/scan:/scanmedia \
 In this example, files ending with `.old` or `.filesync` will be ignored during
 the scan.
 
-If you need to process media files with `ffmpeg`, the binary is available in the
-container at `/ffmpeg`.
+The scanner requires `ffmpeg` (and `ffprobe`) to calculate hashes and read
+metadata. If these binaries are not found at start-up, the program exits with
+`ffmpeg not found`. In the Docker image, they are expected to be available at
+`/ffmpeg`.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ docker build -t uniquemedia-scanner .
 ```
 
 Run the scanner (replace `/path/to/scan` with the directory you want to
-scan):
+scan). The container expects the directory to be mounted at `/scanmedia`:
 
 ```bash
-docker run --rm -v /path/to/scan:/data uniquemedia-scanner /data
+docker run --rm -v /path/to/scan:/scanmedia uniquemedia-scanner
 ```
 
 The scanner will repeat indefinitely until you stop the container.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repository contains a simple directory scanner written in Python. The
 scanner loops endlessly, printing the start of each run and listing all files,
 their sizes and a SHA-256 hash of the contents. Duplicate files are detected by
-comparing hashes only (no metadata is used).
+comparing hashes only. When identical hashes are found, the version containing
+metadata is kept if possible.
 
 ## Running with Docker
 
@@ -20,7 +21,11 @@ scan). The container expects the directory to be mounted at `/scanmedia`:
 docker run --rm -v /path/to/scan:/scanmedia uniquemedia-scanner
 ```
 
-The scanner will repeat indefinitely until you stop the container.
+The scanner will repeat indefinitely until you stop the container. Detected
+duplicate files are moved to the `/double` directory so that only a single copy
+remains in the scanned folder. If one of two identical files contains media
+metadata while the other does not, the metadata-rich file is kept and the other
+is moved.
 
 If you need to process media files with `ffmpeg`, the binary is available in the
 container at `/ffmpeg`.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Uniquemedia Scanner
 
 This repository contains a simple directory scanner written in Python. The
-scanner loops endlessly, printing the start of each run and listing all files,
-their sizes and a SHA-256 hash of the contents. Duplicate files are detected by
-comparing hashes only. When identical hashes are found, the version containing
-metadata is kept if possible.
+scanner loops endlessly, printing `Starte neuen Durchgang` with the iteration
+number at the start of every scan. All files are listed with their sizes and a
+SHA-256 hash of the contents. Duplicate files are detected by comparing hashes
+only. When identical hashes are found, the version containing metadata is kept
+if possible. A file is only considered a duplicate when another path with the
+same hash exists; scanning the same file again will no longer cause it to be
+moved.
 
 ## Running with Docker
 
@@ -15,7 +18,8 @@ docker build -t uniquemedia-scanner .
 ```
 
 Run the scanner (replace `/path/to/scan` with the directory you want to
-scan). The container expects the directory to be mounted at `/scanmedia`:
+scan). The container expects the directory to be mounted at `/scanmedia`.
+If no directory is provided, `/scanmedia` is scanned by default:
 
 ```bash
 docker run --rm -v /path/to/scan:/scanmedia uniquemedia-scanner

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ is moved.
 
 You can exclude certain file extensions from scanning by setting the
 `fileextexept` environment variable. Provide a comma-separated list of
-extensions (with leading dots). The scanner prints the excluded extensions at
-the start of each run:
+extensions (with leading dots). The scanner reads this variable at the start of
+every run and prints the excluded extensions:
 
 ```bash
 docker run --rm -v /path/to/scan:/scanmedia \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Uniquemedia Scanner
+
+This repository contains a simple directory scanner written in Python. The
+scanner loops endlessly, printing the start of each run and listing all files
+and their sizes.
+
+## Running with Docker
+
+Build the image:
+
+```bash
+docker build -t uniquemedia-scanner .
+```
+
+Run the scanner (replace `/path/to/scan` with the directory you want to
+scan):
+
+```bash
+docker run --rm -v /path/to/scan:/data uniquemedia-scanner /data
+```
+
+The scanner will repeat indefinitely until you stop the container.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Uniquemedia Scanner
 
 This repository contains a simple directory scanner written in Python. The
-scanner loops endlessly, printing the start of each run and listing all files
-and their sizes.
+scanner loops endlessly, printing the start of each run and listing all files,
+their sizes and a SHA-256 hash of the contents. Duplicate files are detected by
+comparing hashes only (no metadata is used).
 
 ## Running with Docker
 
@@ -20,3 +21,6 @@ docker run --rm -v /path/to/scan:/scanmedia uniquemedia-scanner
 ```
 
 The scanner will repeat indefinitely until you stop the container.
+
+If you need to process media files with `ffmpeg`, the binary is available in the
+container at `/ffmpeg`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ is moved.
 You can exclude certain file extensions from scanning by setting the
 `fileextexept` environment variable. Provide a comma-separated list of
 extensions (with leading dots). The scanner reads this variable at the start of
-every run and prints the excluded extensions:
+every run and prints the excluded extensions. Quotes around the value (as used
+in some compose files) are stripped automatically:
 
 ```bash
 docker run --rm -v /path/to/scan:/scanmedia \

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 This repository contains a simple directory scanner written in Python. The
 scanner loops endlessly, printing `Starte neuen Durchgang` with the iteration
-number at the start of every scan. All files are listed with their sizes and a
-SHA-256 hash of the contents. Duplicate files are detected by comparing hashes
-only. When identical hashes are found, the version containing metadata is kept
-if possible. A file is only considered a duplicate when another path with the
-same hash exists; scanning the same file again will no longer cause it to be
-moved.
+number at the start of every scan. Files are hashed using ffmpeg's `md5` muxer
+so that metadata is ignored when determining equality. When identical hashes are
+found, the version containing metadata is kept if possible. A file is only
+considered a duplicate when another path with the same hash exists; scanning the
+same file again will no longer cause it to be moved.
 
 ## Running with Docker
 

--- a/scanner.py
+++ b/scanner.py
@@ -82,15 +82,18 @@ def scan_directory(path: str, known: dict[str, tuple[str, bool]]) -> None:
             meta = has_metadata(file_path)
             if digest:
                 if digest in known:
-                    dup_count += 1
                     other_path, other_meta = known[digest]
-                    if meta and not other_meta:
-                        print(f"Duplicate found: {file_path} replaces {other_path} (metadata preference)")
-                        move_to_double(other_path)
-                        known[digest] = (file_path, meta)
-                    else:
-                        print(f"Duplicate found: {file_path} matches {other_path}")
-                        move_to_double(file_path)
+                    if file_path != other_path:
+                        dup_count += 1
+                        if meta and not other_meta:
+                            print(
+                                f"Duplicate found: {file_path} replaces {other_path} (metadata preference)"
+                            )
+                            move_to_double(other_path)
+                            known[digest] = (file_path, meta)
+                        else:
+                            print(f"Duplicate found: {file_path} matches {other_path}")
+                            move_to_double(file_path)
                 else:
                     known[digest] = (file_path, meta)
             print(f"{file_path} - {size} bytes - {digest}")

--- a/scanner.py
+++ b/scanner.py
@@ -7,12 +7,14 @@ import json
 import shutil
 
 
-# Extensions to ignore, read from the environment variable 'fileextexept'.
-EXCLUDE_EXTS = [
-    ext.strip().lower()
-    for ext in os.environ.get("fileextexept", "").split(",")
-    if ext.strip()
-]
+# Helper to read the `fileextexept` environment variable at runtime.
+def get_excluded_exts() -> list[str]:
+    """Return a list of lowercase extensions that should be skipped."""
+    return [
+        ext.strip().lower()
+        for ext in os.environ.get("fileextexept", "").split(",")
+        if ext.strip()
+    ]
 
 
 def file_hash(file_path: str) -> str:
@@ -146,8 +148,8 @@ def main() -> None:
     path = sys.argv[1] if len(sys.argv) > 1 else '/scanmedia'
     run = 1
     known: dict[str, tuple[str, bool]] = {}
-    exclude_exts = EXCLUDE_EXTS
     while True:
+        exclude_exts = get_excluded_exts()
         print(f"Starte neuen Durchgang Nr: {run}")
         if exclude_exts:
             print("Ausgeschlossene Dateiendungen: " + ", ".join(exclude_exts))

--- a/scanner.py
+++ b/scanner.py
@@ -2,6 +2,9 @@ import os
 import time
 import sys
 import hashlib
+import subprocess
+import json
+import shutil
 
 
 def file_hash(file_path: str) -> str:
@@ -16,8 +19,56 @@ def file_hash(file_path: str) -> str:
     return h.hexdigest()
 
 
-def scan_directory(path: str, known: dict[str, str]) -> None:
-    """Scan a directory recursively, print file info and detect duplicates."""
+def has_metadata(file_path: str) -> bool:
+    """Return True if ffprobe detects metadata in the file."""
+    ffprobe_paths = [
+        "/ffmpeg/ffprobe",
+        "/ffprobe",
+        "/usr/bin/ffprobe",
+        "/ffmpeg",
+    ]
+    for bin_path in ffprobe_paths:
+        if os.path.exists(bin_path):
+            try:
+                result = subprocess.run(
+                    [bin_path, "-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", file_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.returncode == 0:
+                    try:
+                        info = json.loads(result.stdout)
+                    except json.JSONDecodeError:
+                        continue
+                    if info.get("format", {}).get("tags"):
+                        return True
+                    for st in info.get("streams", []):
+                        if st.get("tags"):
+                            return True
+            except Exception:
+                pass
+    return False
+
+
+def move_to_double(file_path: str, double_dir: str = "/double") -> None:
+    """Move a file to the duplicate directory, avoiding name collisions."""
+    try:
+        os.makedirs(double_dir, exist_ok=True)
+        base_name = os.path.basename(file_path)
+        dest = os.path.join(double_dir, base_name)
+        counter = 1
+        while os.path.exists(dest):
+            dest = os.path.join(double_dir, f"{base_name}.{counter}")
+            counter += 1
+        shutil.move(file_path, dest)
+        print(f"Moved {file_path} to {dest}")
+    except OSError as e:
+        print(f"Failed to move {file_path} to {double_dir}: {e}")
+
+
+def scan_directory(path: str, known: dict[str, tuple[str, bool]]) -> None:
+    """Scan a directory recursively, print file info and handle duplicates."""
     file_count = 0
     dup_count = 0
     for root, dirs, files in os.walk(path):
@@ -28,12 +79,20 @@ def scan_directory(path: str, known: dict[str, str]) -> None:
             except OSError:
                 size = -1
             digest = file_hash(file_path)
+            meta = has_metadata(file_path)
             if digest:
                 if digest in known:
                     dup_count += 1
-                    print(f"Duplicate found: {file_path} matches {known[digest]}")
+                    other_path, other_meta = known[digest]
+                    if meta and not other_meta:
+                        print(f"Duplicate found: {file_path} replaces {other_path} (metadata preference)")
+                        move_to_double(other_path)
+                        known[digest] = (file_path, meta)
+                    else:
+                        print(f"Duplicate found: {file_path} matches {other_path}")
+                        move_to_double(file_path)
                 else:
-                    known[digest] = file_path
+                    known[digest] = (file_path, meta)
             print(f"{file_path} - {size} bytes - {digest}")
             file_count += 1
     print(f"Durchlauf abgeschlossen. {file_count} Dateien gefunden, {dup_count} Duplikate.")
@@ -42,7 +101,7 @@ def scan_directory(path: str, known: dict[str, str]) -> None:
 def main() -> None:
     path = sys.argv[1] if len(sys.argv) > 1 else '/scanmedia'
     run = 1
-    known: dict[str, str] = {}
+    known: dict[str, tuple[str, bool]] = {}
     while True:
         print(f"Starte neuen Durchgang Nr: {run}")
         scan_directory(path, known)

--- a/scanner.py
+++ b/scanner.py
@@ -19,7 +19,7 @@ def scan_directory(path: str) -> None:
 
 
 def main() -> None:
-    path = sys.argv[1] if len(sys.argv) > 1 else '.'
+    path = sys.argv[1] if len(sys.argv) > 1 else '/scanmedia'
     run = 1
     while True:
         print(f"Starte neuen Durchgang Nr: {run}")

--- a/scanner.py
+++ b/scanner.py
@@ -10,11 +10,13 @@ import shutil
 # Helper to read the `fileextexept` environment variable at runtime.
 def get_excluded_exts() -> list[str]:
     """Return a list of lowercase extensions that should be skipped."""
-    return [
-        ext.strip().lower()
-        for ext in os.environ.get("fileextexept", "").split(",")
-        if ext.strip()
-    ]
+    cleaned: list[str] = []
+    raw = os.environ.get("fileextexept", "")
+    for ext in raw.split(','):
+        ext = ext.strip().strip('"').strip("'").lower()
+        if ext:
+            cleaned.append(ext)
+    return cleaned
 
 
 def file_hash(file_path: str) -> str:

--- a/scanner.py
+++ b/scanner.py
@@ -1,1 +1,35 @@
-fa
+import os
+import time
+import sys
+
+
+def scan_directory(path: str) -> None:
+    """Scan a directory recursively and print each file path and size."""
+    file_count = 0
+    for root, dirs, files in os.walk(path):
+        for name in files:
+            file_path = os.path.join(root, name)
+            try:
+                size = os.path.getsize(file_path)
+            except OSError:
+                size = -1
+            print(f"{file_path} - {size} bytes")
+            file_count += 1
+    print(f"Durchlauf abgeschlossen. {file_count} Dateien gefunden.")
+
+
+def main() -> None:
+    path = sys.argv[1] if len(sys.argv) > 1 else '.'
+    run = 1
+    while True:
+        print(f"Starte neuen Durchgang Nr: {run}")
+        scan_directory(path)
+        run += 1
+        time.sleep(1)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("Beendet durch Benutzer")

--- a/scanner.py
+++ b/scanner.py
@@ -1,11 +1,25 @@
 import os
 import time
 import sys
+import hashlib
 
 
-def scan_directory(path: str) -> None:
-    """Scan a directory recursively and print each file path and size."""
+def file_hash(file_path: str) -> str:
+    """Return SHA-256 hash of a file's contents."""
+    h = hashlib.sha256()
+    try:
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+    except OSError:
+        return ""
+    return h.hexdigest()
+
+
+def scan_directory(path: str, known: dict[str, str]) -> None:
+    """Scan a directory recursively, print file info and detect duplicates."""
     file_count = 0
+    dup_count = 0
     for root, dirs, files in os.walk(path):
         for name in files:
             file_path = os.path.join(root, name)
@@ -13,17 +27,25 @@ def scan_directory(path: str) -> None:
                 size = os.path.getsize(file_path)
             except OSError:
                 size = -1
-            print(f"{file_path} - {size} bytes")
+            digest = file_hash(file_path)
+            if digest:
+                if digest in known:
+                    dup_count += 1
+                    print(f"Duplicate found: {file_path} matches {known[digest]}")
+                else:
+                    known[digest] = file_path
+            print(f"{file_path} - {size} bytes - {digest}")
             file_count += 1
-    print(f"Durchlauf abgeschlossen. {file_count} Dateien gefunden.")
+    print(f"Durchlauf abgeschlossen. {file_count} Dateien gefunden, {dup_count} Duplikate.")
 
 
 def main() -> None:
     path = sys.argv[1] if len(sys.argv) > 1 else '/scanmedia'
     run = 1
+    known: dict[str, str] = {}
     while True:
         print(f"Starte neuen Durchgang Nr: {run}")
-        scan_directory(path)
+        scan_directory(path, known)
         run += 1
         time.sleep(1)
 


### PR DESCRIPTION
## Summary
- replace the empty `scanner.py` with a working script
- implement a directory scanner that prints the current run number
- repeat scans endlessly until interrupted

## Testing
- `python3 scanner.py .`

------
https://chatgpt.com/codex/tasks/task_e_6873d910a6f8832fafadc419a38f4e77